### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 MCP server for adding movies and TV shows to Radarr/Sonarr via natural language queries.
 
+<a href="https://glama.ai/mcp/servers/@omniwaifu/arr-assistant-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@omniwaifu/arr-assistant-mcp/badge" alt="arr-assistant-mcp MCP server" />
+</a>
+
 ## Setup
 
 Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/).


### PR DESCRIPTION
This PR adds a badge for the [arr-assistant-mcp](https://glama.ai/mcp/servers/@omniwaifu/arr-assistant-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@omniwaifu/arr-assistant-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@omniwaifu/arr-assistant-mcp/badge" alt="arr-assistant-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.