### PR TITLE
Harden Arr HTTP handling and release supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: npm
+    directory: /.github/mcpb-tooling
+    schedule:
+      interval: weekly

--- a/.github/mcpb-tooling/package-lock.json
+++ b/.github/mcpb-tooling/package-lock.json
@@ -1,0 +1,639 @@
+{
+  "name": "arr-assistant-mcpb-tooling",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "arr-assistant-mcpb-tooling",
+      "version": "0.0.0",
+      "dependencies": {
+        "@anthropic-ai/mcpb": "2.1.2"
+      }
+    },
+    "node_modules/@anthropic-ai/mcpb": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/mcpb/-/mcpb-2.1.2.tgz",
+      "integrity": "sha512-goRbBC8ySo7SWb7tRzr+tL6FxDc4JPTRCdgfD2omba7freofvjq5rom1lBnYHZHo6Mizs1jAHJeN53aZbDoy8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/prompts": "^6.0.1",
+        "commander": "^13.1.0",
+        "fflate": "^0.8.2",
+        "galactus": "^1.0.0",
+        "ignore": "^7.0.5",
+        "node-forge": "^1.3.2",
+        "pretty-bytes": "^5.6.0",
+        "zod": "^3.25.67",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "mcpb": "dist/cli/cli.js"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
+      "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+      "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "@types/mute-stream": "^0.0.4",
+        "@types/node": "^22.5.5",
+        "@types/wrap-ansi": "^3.0.0",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^1.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
+      "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
+      "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
+      "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
+      "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
+      "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
+      "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^3.0.1",
+        "@inquirer/confirm": "^4.0.1",
+        "@inquirer/editor": "^3.0.1",
+        "@inquirer/expand": "^3.0.1",
+        "@inquirer/input": "^3.0.1",
+        "@inquirer/number": "^2.0.1",
+        "@inquirer/password": "^3.0.1",
+        "@inquirer/rawlist": "^3.0.1",
+        "@inquirer/search": "^2.0.1",
+        "@inquirer/select": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
+      "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
+      "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
+      "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^9.2.1",
+        "@inquirer/figures": "^1.0.6",
+        "@inquirer/type": "^2.0.0",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/mute-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/wrap-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/flora-colossus": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-2.0.0.tgz",
+      "integrity": "sha512-dz4HxH6pOvbUzZpZ/yXhafjbR2I8cenK5xL0KtBFb7U2ADsR+OwXifnxZjij/pZWF775uSCMzWVd+jDik2H2IA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/galactus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-1.0.0.tgz",
+      "integrity": "sha512-R1fam6D4CyKQGNlvJne4dkNF+PvUUl7TAJInvTGa9fti9qAv95quQz29GXapA4d8Ec266mJJxFVh82M4GIIGDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "flora-colossus": "^2.0.0",
+        "fs-extra": "^10.1.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/.github/mcpb-tooling/package.json
+++ b/.github/mcpb-tooling/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "arr-assistant-mcpb-tooling",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Pinned tooling used to validate and build the Arr Assistant MCPB",
+  "dependencies": {
+    "@anthropic-ai/mcpb": "2.1.2"
+  },
+  "overrides": {
+    "tmp": "0.2.7"
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.28"
           enable-cache: true
@@ -50,21 +50,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.28"
           enable-cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 
@@ -77,11 +77,17 @@ jobs:
       - name: Audit installed dependencies
         run: uv run pip-audit --local
 
+      - name: Install MCPB tooling
+        run: npm ci --prefix .github/mcpb-tooling --ignore-scripts
+
+      - name: Audit MCPB tooling
+        run: npm audit --prefix .github/mcpb-tooling --audit-level=moderate
+
       - name: Validate MCPB manifest
-        run: npx -y @anthropic-ai/mcpb@2.1.2 validate manifest.json
+        run: npm exec --prefix .github/mcpb-tooling -- mcpb validate manifest.json
 
       - name: Pack MCPB bundle
-        run: npx -y @anthropic-ai/mcpb@2.1.2 pack . /tmp/arr-assistant-mcp.mcpb
+        run: npm exec --prefix .github/mcpb-tooling -- mcpb pack . /tmp/arr-assistant-mcp.mcpb
 
       - name: Inspect MCPB bundle
-        run: npx -y @anthropic-ai/mcpb@2.1.2 info /tmp/arr-assistant-mcp.mcpb
+        run: npm exec --prefix .github/mcpb-tooling -- mcpb info /tmp/arr-assistant-mcp.mcpb

--- a/.github/workflows/mcpb-release.yml
+++ b/.github/workflows/mcpb-release.yml
@@ -6,29 +6,29 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  build-and-release:
+  build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           version: "0.11.28"
           enable-cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 
@@ -49,6 +49,12 @@ jobs:
 
       - name: Audit installed dependencies
         run: uv run pip-audit --local
+
+      - name: Install MCPB tooling
+        run: npm ci --prefix .github/mcpb-tooling --ignore-scripts
+
+      - name: Audit MCPB tooling
+        run: npm audit --prefix .github/mcpb-tooling --audit-level=moderate
 
       - name: Verify release version metadata
         run: |
@@ -78,24 +84,50 @@ jobs:
         run: uv build
 
       - name: Validate MCPB manifest
-        run: npx -y @anthropic-ai/mcpb@2.1.2 validate manifest.json
+        run: npm exec --prefix .github/mcpb-tooling -- mcpb validate manifest.json
 
       - name: Pack MCPB bundle
-        run: npx -y @anthropic-ai/mcpb@2.1.2 pack . dist/arr-assistant-mcp-${{ github.ref_name }}.mcpb
+        run: npm exec --prefix .github/mcpb-tooling -- mcpb pack . dist/arr-assistant-mcp-${{ github.ref_name }}.mcpb
 
       - name: Inspect MCPB bundle
-        run: npx -y @anthropic-ai/mcpb@2.1.2 info dist/arr-assistant-mcp-${{ github.ref_name }}.mcpb
+        run: npm exec --prefix .github/mcpb-tooling -- mcpb info dist/arr-assistant-mcp-${{ github.ref_name }}.mcpb
 
-      - name: Create GitHub release
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-artifacts
+          path: |
+            dist/arr-assistant-mcp-${{ github.ref_name }}.mcpb
+            dist/*.whl
+            dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-artifacts
+          path: dist
+
+      - name: Create GitHub release if needed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "${GITHUB_REF_NAME}" --verify-tag --generate-notes
+          GH_REPO: ${{ github.repository }}
+        run: gh release view "${GITHUB_REF_NAME}" >/dev/null || gh release create "${GITHUB_REF_NAME}" --verify-tag --generate-notes
 
       - name: Upload release artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release upload "${GITHUB_REF_NAME}" \
             dist/arr-assistant-mcp-${GITHUB_REF_NAME}.mcpb \
             dist/*.whl \
-            dist/*.tar.gz
+            dist/*.tar.gz \
+            --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ htmlcov/
 # Bundle artifacts
 *.dxt
 *.mcpb
+
+# Node tooling
+node_modules/

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Add this to your `claude_desktop_config.json` to run the checked-out project dir
         "src/arr_assistant_mcp/main.py"
       ],
       "env": {
-        "RADARR_URL": "http://your-ip:7878",
+        "RADARR_URL": "https://radarr.example.com",
         "RADARR_API_KEY": "your-radarr-api-key",
-        "SONARR_URL": "http://your-ip:8989",
+        "SONARR_URL": "https://sonarr.example.com",
         "SONARR_API_KEY": "your-sonarr-api-key",
         "QUALITY_PROFILE_ID": "1",
         "RADARR_ROOT_FOLDER": "/storage/movies",
@@ -47,15 +47,19 @@ Add this to your `claude_desktop_config.json` to run the checked-out project dir
 
 Trailing slashes in `RADARR_URL` and `SONARR_URL` are normalized automatically. API keys are
 required for the corresponding service. Never commit them; pass them through your MCP client or
-local environment.
+local environment. Prefer HTTPS because Arr API keys are sent with every request. Plain HTTP is
+safe for loopback URLs; for a trusted LAN or VPN where HTTPS is unavailable, the server allows
+plain HTTP but logs a warning identifying the service and destination.
 
 ## Build An MCP Bundle
 
 Packaged release artifacts should now use the `.mcpb` extension.
 
 ```bash
-npx -y @anthropic-ai/mcpb@2.1.2 validate manifest.json
-npx -y @anthropic-ai/mcpb@2.1.2 pack . arr-assistant-mcp.mcpb
+npm ci --prefix .github/mcpb-tooling --ignore-scripts
+npm audit --prefix .github/mcpb-tooling --audit-level=moderate
+npm exec --prefix .github/mcpb-tooling -- mcpb validate manifest.json
+npm exec --prefix .github/mcpb-tooling -- mcpb pack . arr-assistant-mcp.mcpb
 ```
 
 Open the resulting `.mcpb` file in Claude Desktop to install it.
@@ -105,9 +109,9 @@ read-only status and root-folder requests against locally configured services:
 
 ```bash
 ARR_ASSISTANT_LIVE_TESTS=1 \
-RADARR_URL=http://your-arr-host:7878 \
+RADARR_URL=https://radarr.example.com \
 RADARR_API_KEY=your-radarr-api-key \
-SONARR_URL=http://your-arr-host:8989 \
+SONARR_URL=https://sonarr.example.com \
 SONARR_API_KEY=your-sonarr-api-key \
 uv run pytest tests/test_live.py -v
 ```

--- a/manifest.json
+++ b/manifest.json
@@ -91,7 +91,7 @@
     "radarr_url": {
       "type": "string",
       "title": "Radarr URL",
-      "description": "URL to your Radarr instance (for example, http://192.168.1.11:7878)",
+      "description": "URL to your Radarr instance (HTTPS recommended; plain HTTP sends the API key unencrypted)",
       "required": true
     },
     "radarr_api_key": {
@@ -104,7 +104,7 @@
     "sonarr_url": {
       "type": "string",
       "title": "Sonarr URL",
-      "description": "URL to your Sonarr instance (for example, http://192.168.1.11:8989)",
+      "description": "URL to your Sonarr instance (HTTPS recommended; plain HTTP sends the API key unencrypted)",
       "required": true
     },
     "sonarr_api_key": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 license = "MIT"
 license-files = ["LICENSE"]
 dependencies = [
-    "fastmcp>=3.4.4",
+    "fastmcp>=3.4.5,<4",
     "httpx>=0.28.1",
     "pydantic>=2.13.4",
 ]

--- a/src/arr_assistant_mcp/main.py
+++ b/src/arr_assistant_mcp/main.py
@@ -1,10 +1,12 @@
 """Arr Assistant MCP server for Radarr and Sonarr."""
 
+import ipaddress
 import logging
 import os
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 from fastmcp import FastMCP
@@ -15,6 +17,17 @@ logger = logging.getLogger(__name__)
 DEFAULT_RADARR_URL = "http://localhost:7878"
 DEFAULT_SONARR_URL = "http://localhost:8989"
 DEFAULT_QUALITY_PROFILE_ID = 1
+MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+RESPONSE_CHUNK_BYTES = 64 * 1024
+
+
+class ArrResponseTooLargeError(httpx.HTTPError):
+    """Raised when an Arr server returns more decoded data than we accept."""
+
+    def __init__(self, service: str):
+        super().__init__(
+            f"{service} response exceeded the {MAX_RESPONSE_BYTES // (1024 * 1024)} MiB limit"
+        )
 
 
 # Configuration models
@@ -31,6 +44,38 @@ class ServerConfig:
     def __post_init__(self) -> None:
         self.radarr_url = self.radarr_url.rstrip("/")
         self.sonarr_url = self.sonarr_url.rstrip("/")
+        self._warn_for_plaintext_credentials("Radarr", self.radarr_url)
+        self._warn_for_plaintext_credentials("Sonarr", self.sonarr_url)
+
+    @staticmethod
+    def _warn_for_plaintext_credentials(service: str, url: str) -> None:
+        parsed = urlsplit(url)
+        if parsed.scheme.lower() != "http" or not parsed.hostname:
+            return
+
+        hostname = parsed.hostname.rstrip(".").lower()
+        is_loopback = hostname == "localhost" or hostname.endswith(".localhost")
+        if not is_loopback:
+            try:
+                is_loopback = ipaddress.ip_address(hostname).is_loopback
+            except ValueError:
+                pass
+
+        if is_loopback:
+            return
+
+        display_host = f"[{hostname}]" if ":" in hostname else hostname
+        try:
+            display_port = f":{parsed.port}" if parsed.port is not None else ""
+        except ValueError:
+            display_port = ""
+        origin = f"http://{display_host}{display_port}"
+        logger.warning(
+            "%s API credentials will be sent over plaintext HTTP to %s; "
+            "use HTTPS or a trusted private network",
+            service,
+            origin,
+        )
 
 
 # Response models
@@ -82,6 +127,34 @@ class MediaServerAPI:
             await self.client.aclose()
 
     @staticmethod
+    async def _read_bounded_response(
+        response: httpx.Response,
+        service: str,
+    ) -> bytes:
+        body = bytearray()
+        async for chunk in response.aiter_bytes(chunk_size=RESPONSE_CHUNK_BYTES):
+            if len(chunk) > MAX_RESPONSE_BYTES - len(body):
+                raise ArrResponseTooLargeError(service)
+            body.extend(chunk)
+        return bytes(body)
+
+    async def _request(
+        self,
+        service: str,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        async with self.client.stream(method, url, **kwargs) as response:
+            body = await self._read_bounded_response(response, service)
+            return httpx.Response(
+                status_code=response.status_code,
+                headers=response.headers,
+                content=body,
+                request=response.request,
+            )
+
+    @staticmethod
     def _extract_error_message(response: httpx.Response) -> str:
         try:
             payload = response.json()
@@ -119,7 +192,7 @@ class MediaServerAPI:
         headers = {"X-Api-Key": self.config.radarr_api_key}
 
         try:
-            response = await self.client.get(url, headers=headers)
+            response = await self._request("Radarr", "GET", url, headers=headers)
             response.raise_for_status()
             payload = response.json()
             return payload if isinstance(payload, list) else []
@@ -133,7 +206,7 @@ class MediaServerAPI:
         headers = {"X-Api-Key": self.config.sonarr_api_key}
 
         try:
-            response = await self.client.get(url, headers=headers)
+            response = await self._request("Sonarr", "GET", url, headers=headers)
             response.raise_for_status()
             payload = response.json()
             return payload if isinstance(payload, list) else []
@@ -150,7 +223,13 @@ class MediaServerAPI:
         logger.info(f"Radarr lookup request: {url} with term='{query}'")
 
         try:
-            response = await self.client.get(url, params=params, headers=headers)
+            response = await self._request(
+                "Radarr",
+                "GET",
+                url,
+                params=params,
+                headers=headers,
+            )
             logger.info(f"Radarr response status: {response.status_code}")
 
             if response.status_code == 401:
@@ -162,6 +241,8 @@ class MediaServerAPI:
 
             response.raise_for_status()
             results = response.json()
+            if not isinstance(results, list):
+                raise ValueError("Radarr lookup response was not a list")
             logger.info(f"Radarr returned {len(results)} results for query '{query}'")
 
             if results:
@@ -217,7 +298,13 @@ class MediaServerAPI:
             logger.info("Using auto-detected Radarr root folder: %s", detected_root_folder)
 
         try:
-            response = await self.client.post(url, json=payload, headers=headers)
+            response = await self._request(
+                "Radarr",
+                "POST",
+                url,
+                json=payload,
+                headers=headers,
+            )
             if response.is_success:
                 result = response.json()
                 return AddMediaResponse(
@@ -229,7 +316,7 @@ class MediaServerAPI:
                 success=False,
                 message=f"Failed to add movie: {self._extract_error_message(response)}",
             )
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, ArrResponseTooLargeError) as exc:
             logger.error("Radarr API error: %s", exc)
             return AddMediaResponse(
                 success=False,
@@ -251,7 +338,13 @@ class MediaServerAPI:
         logger.info(f"Sonarr lookup request: {url} with term='{query}'")
 
         try:
-            response = await self.client.get(url, params=params, headers=headers)
+            response = await self._request(
+                "Sonarr",
+                "GET",
+                url,
+                params=params,
+                headers=headers,
+            )
             logger.info(f"Sonarr response status: {response.status_code}")
 
             if response.status_code == 401:
@@ -263,6 +356,8 @@ class MediaServerAPI:
 
             response.raise_for_status()
             results = response.json()
+            if not isinstance(results, list):
+                raise ValueError("Sonarr lookup response was not a list")
             logger.info(f"Sonarr returned {len(results)} results for query '{query}'")
 
             if results:
@@ -314,7 +409,13 @@ class MediaServerAPI:
             logger.info("Using auto-detected Sonarr root folder: %s", detected_root_folder)
 
         try:
-            response = await self.client.post(url, json=payload, headers=headers)
+            response = await self._request(
+                "Sonarr",
+                "POST",
+                url,
+                json=payload,
+                headers=headers,
+            )
             if response.is_success:
                 result = response.json()
                 return AddMediaResponse(
@@ -326,7 +427,7 @@ class MediaServerAPI:
                 success=False,
                 message=f"Failed to add series: {self._extract_error_message(response)}",
             )
-        except httpx.RequestError as exc:
+        except (httpx.RequestError, ArrResponseTooLargeError) as exc:
             logger.error("Sonarr API error: %s", exc)
             return AddMediaResponse(
                 success=False,
@@ -345,12 +446,12 @@ class MediaServerAPI:
         headers = {"X-Api-Key": self.config.radarr_api_key}
 
         try:
-            response = await self.client.get(url, headers=headers)
+            response = await self._request("Radarr", "GET", url, headers=headers)
             response.raise_for_status()
             return {"status": "connected", "data": response.json()}
         except httpx.HTTPStatusError as exc:
             return {"status": "error", "message": self._extract_error_message(exc.response)}
-        except (httpx.RequestError, ValueError) as exc:
+        except (httpx.RequestError, ArrResponseTooLargeError, ValueError) as exc:
             return {"status": "error", "message": str(exc)}
 
     async def check_sonarr_status(self) -> dict[str, Any]:
@@ -359,12 +460,12 @@ class MediaServerAPI:
         headers = {"X-Api-Key": self.config.sonarr_api_key}
 
         try:
-            response = await self.client.get(url, headers=headers)
+            response = await self._request("Sonarr", "GET", url, headers=headers)
             response.raise_for_status()
             return {"status": "connected", "data": response.json()}
         except httpx.HTTPStatusError as exc:
             return {"status": "error", "message": self._extract_error_message(exc.response)}
-        except (httpx.RequestError, ValueError) as exc:
+        except (httpx.RequestError, ArrResponseTooLargeError, ValueError) as exc:
             return {"status": "error", "message": str(exc)}
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import gzip
 import json
+import logging
 import tomllib
-from collections.abc import Generator
+from collections.abc import AsyncIterator, Generator
 from pathlib import Path
 
 import httpx
@@ -11,7 +13,12 @@ from fastmcp import Client
 
 from arr_assistant_mcp import __version__
 from arr_assistant_mcp import main as server_main
-from arr_assistant_mcp.main import AddMediaResponse, MediaServerAPI, ServerConfig
+from arr_assistant_mcp.main import (
+    AddMediaResponse,
+    ArrResponseTooLargeError,
+    MediaServerAPI,
+    ServerConfig,
+)
 
 
 def make_config() -> ServerConfig:
@@ -37,6 +44,176 @@ def test_server_config_normalizes_base_urls() -> None:
 
     assert config.radarr_url == "http://radarr.local"
     assert config.sonarr_url == "http://sonarr.local"
+
+
+@pytest.mark.parametrize(
+    ("url", "should_warn"),
+    [
+        ("http://localhost:7878", False),
+        ("http://radarr.localhost:7878", False),
+        ("http://127.0.0.1:7878", False),
+        ("http://[::1]:7878", False),
+        ("https://radarr.example.com", False),
+        ("http://192.168.1.11:7878", True),
+        ("http://radarr.internal:7878", True),
+    ],
+)
+def test_server_config_warns_for_non_loopback_plaintext_http(
+    url: str,
+    should_warn: bool,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger=server_main.__name__)
+
+    ServerConfig(
+        radarr_url=url,
+        radarr_api_key="secret-api-key",
+        sonarr_url="https://sonarr.example.com",
+        sonarr_api_key="another-secret",
+    )
+
+    warnings = [record.getMessage() for record in caplog.records]
+    assert bool(warnings) is should_warn
+    assert all("secret-api-key" not in warning for warning in warnings)
+    assert all("another-secret" not in warning for warning in warnings)
+    if should_warn:
+        assert warnings == [
+            f"Radarr API credentials will be sent over plaintext HTTP to "
+            f"{url}; use HTTPS or a trusted private network"
+        ]
+
+
+def test_server_config_warns_once_for_each_plaintext_service(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger=server_main.__name__)
+
+    ServerConfig(
+        radarr_url="http://radarr.internal:7878",
+        radarr_api_key="radarr-key",
+        sonarr_url="http://sonarr.internal:8989",
+        sonarr_api_key="sonarr-key",
+    )
+
+    assert [record.getMessage() for record in caplog.records] == [
+        "Radarr API credentials will be sent over plaintext HTTP to "
+        "http://radarr.internal:7878; use HTTPS or a trusted private network",
+        "Sonarr API credentials will be sent over plaintext HTTP to "
+        "http://sonarr.internal:8989; use HTTPS or a trusted private network",
+    ]
+
+
+class TrackingStream(httpx.AsyncByteStream):
+    def __init__(self, chunks: list[bytes]):
+        self.chunks = chunks
+        self.closed = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self.chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.parametrize("payload", [b"1234", b"12345678"])
+@pytest.mark.asyncio
+async def test_bounded_reader_accepts_payloads_through_exact_limit_and_closes_response(
+    payload: bytes,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server_main, "MAX_RESPONSE_BYTES", 8)
+    stream = TrackingStream([payload])
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream, request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        api = MediaServerAPI(make_config(), client=client)
+        response = await api._request("Radarr", "GET", "http://radarr.local/test")
+
+    assert response.content == payload
+    assert stream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_bounded_reader_rejects_chunked_overflow_and_closes_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server_main, "MAX_RESPONSE_BYTES", 8)
+    stream = TrackingStream([b"1234", b"5678", b"9"])
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=stream, request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        api = MediaServerAPI(make_config(), client=client)
+        with pytest.raises(ArrResponseTooLargeError, match="Radarr response exceeded"):
+            await api._request("Radarr", "GET", "http://radarr.local/test")
+
+    assert stream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_bounded_reader_limits_decoded_compressed_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server_main, "MAX_RESPONSE_BYTES", 8)
+    compressed = gzip.compress(b"123456789")
+    stream = TrackingStream([compressed])
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"Content-Encoding": "gzip"},
+            stream=stream,
+            request=request,
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        api = MediaServerAPI(make_config(), client=client)
+        with pytest.raises(ArrResponseTooLargeError, match="Radarr response exceeded"):
+            await api._request("Radarr", "GET", "http://radarr.local/test")
+
+    assert stream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_all_arr_response_paths_enforce_shared_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server_main, "MAX_RESPONSE_BYTES", 8)
+    config = make_config()
+    config.radarr_root_folder = "/movies"
+    config.sonarr_root_folder = "/shows"
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"123456789", request=request)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        api = MediaServerAPI(config, client=client)
+
+        assert await api.get_radarr_root_folders() == []
+        assert await api.get_sonarr_root_folders() == []
+
+        with pytest.raises(ArrResponseTooLargeError):
+            await api.search_radarr_movies("Matrix")
+        with pytest.raises(ArrResponseTooLargeError):
+            await api.search_sonarr_shows("Doctor Who")
+
+        movie_result = await api.add_movie_to_radarr(603, "The Matrix")
+        show_result = await api.add_series_to_sonarr(78804, "Doctor Who")
+        assert movie_result.success is False
+        assert "exceeded the" in movie_result.message
+        assert show_result.success is False
+        assert "exceeded the" in show_result.message
+
+        radarr_status = await api.check_radarr_status()
+        sonarr_status = await api.check_sonarr_status()
+        assert radarr_status["status"] == "error"
+        assert "exceeded the" in radarr_status["message"]
+        assert sonarr_status["status"] == "error"
+        assert "exceeded the" in sonarr_status["message"]
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastmcp", specifier = ">=3.4.4" },
+    { name = "fastmcp", specifier = ">=3.4.5,<4" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.13.4" },
 ]
@@ -474,19 +474,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.4"
+version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/f7/5188565d1b93ad611cbd80bf473e7ad669d1f3b689c4bedcd304e1ec3472/fastmcp-3.4.4.tar.gz", hash = "sha256:378202e26ec15b23819d9a1c0d1b0ebda096bc712720532010a0b82a45c2b1df", size = 28796458, upload-time = "2026-07-09T00:32:41.352Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/14/c1ffb91b7d1fece86c81e1f9df5474f30fd97e4cdaa398814bbbeee88568/fastmcp-3.4.5.tar.gz", hash = "sha256:a95f2bc876bef42e8b50f7872f24f3f2fe3b1d37408c734e8b9d9e03014b72d3", size = 28800521, upload-time = "2026-07-27T19:20:01.231Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/67/3cef84ba38a23dca1e1e776bfda8a35ab3c7a6c94a8ca81d0715de6dd3c5/fastmcp-3.4.4-py3-none-any.whl", hash = "sha256:f86f208713212260068cf55c32936839eee856fefc7808e18a032f31eb0f718e", size = 8019, upload-time = "2026-07-09T00:32:39.411Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4f/73450a436c963c0382d15a882fc5d08f15aadc329194df1b54495a7c8383/fastmcp-3.4.5-py3-none-any.whl", hash = "sha256:5d3d438eb2917e63e6faf53e8cb8fe26d887ec3232f848093a4eecad7fa34861", size = 8017, upload-time = "2026-07-27T19:19:57.942Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.4"
+version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -496,9 +496,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/1d/f3e271fbcd01ce01a4cf623b336d8e1305c192aa5d5e8e0223b7167462e9/fastmcp_slim-3.4.5.tar.gz", hash = "sha256:5badc3bceee61f61297eeb9494f499325f3ce1cafabf4611b31f6c3e9d7dff59", size = 591622, upload-time = "2026-07-27T19:15:19.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3b/16d8aa8224094519f30b078138e725b8a731bf0a13f1f850e58b5f9b3cc4/fastmcp_slim-3.4.5-py3-none-any.whl", hash = "sha256:bc31217827c4999812543c83ee95ed9a47f3ed1e3fd0bd4f64371e375b748eca", size = 766478, upload-time = "2026-07-27T19:15:18.015Z" },
 ]
 
 [package.optional-dependencies]
@@ -765,7 +765,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -783,9 +783,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- bound all decoded Radarr and Sonarr response bodies to 4 MiB while preserving existing tool contracts
- warn when Arr API credentials use non-loopback plaintext HTTP, without logging secrets
- update the stable dependency line to FastMCP 3.4.5 and MCP 1.29.0
- replace ephemeral MCPB downloads with lockfile-backed, audited tooling
- pin every GitHub Action to a full commit SHA
- split release building from the minimal write-permission publishing job

## Why

A Codex Security scan identified plaintext credential transport risk, unbounded response consumption, mutable workflow dependencies, and non-reproducible MCPB tooling. The scan artifact itself failed to save because of a scanner `snapshotDigest` persistence error, but its partial findings were complete enough to investigate and reproduce independently.

## Impact

Plain HTTP remains supported for trusted LAN or VPN installations, with a warning. Loopback HTTP remains quiet. Oversized Arr responses now fail safely according to each method's established return or exception contract. Release artifacts are built under read-only permissions and only the verified artifact is passed to the write-enabled publishing job.

## Validation

- `uv lock --check`
- `uv sync --group dev --frozen`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest` — 27 passed, 1 live test skipped
- `uv run pip-audit --local` — no known third-party vulnerabilities
- `npm ci --prefix .github/mcpb-tooling --ignore-scripts`
- `npm audit --prefix .github/mcpb-tooling --audit-level=moderate` — 0 vulnerabilities
- MCPB validate, pack, and info checks
- verified the MCPB excludes `.github` and `node_modules`
- `uv build`
- `actionlint`
- `git diff --check`

The live Arr test and remote release workflow are intentionally not run by this commit.