### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,6 @@ keys into source files, test fixtures, shell scripts, or commits.
 ## Releases
 
 Versions are kept in sync across `pyproject.toml`, `manifest.json`, and the package. Pushing a tag
-matching the project version (for example, `v0.2.0`) runs linting, tests, a dependency
+matching the project version (for example, `v0.2.1`) runs linting, tests, a dependency
 audit, and package validation before publishing the MCPB, wheel, and source distribution to a
 GitHub release.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "arr-assistant-mcp",
   "display_name": "Arr Assistant MCP Server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "MCP server for searching and adding movies and TV shows in Radarr and Sonarr",
   "long_description": "A streamlined MCP server that provides tools for searching movies and TV shows, adding them to Radarr and Sonarr, and checking server connectivity with automatic root folder detection.",
   "author": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arr-assistant-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "MCP server for searching and adding movies and TV shows in Radarr and Sonarr"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/arr_assistant_mcp/__init__.py
+++ b/src/arr_assistant_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Arr Assistant MCP."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "arr-assistant-mcp"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What changed

- bump package metadata from 0.2.0 to 0.2.1
- keep `pyproject.toml`, `manifest.json`, package `__version__`, README release example, and `uv.lock` synchronized

## Why

This patch release publishes the security hardening merged in #6 without moving or replacing the existing `v0.2.0` tag.

## Validation

- `uv lock`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest` — 27 passed, 1 live test skipped
- MCPB manifest validation
- `git diff --check`